### PR TITLE
Fix FixedLengthWithOffsetInputFormat record key

### DIFF
--- a/src/main/java/org/ode/hadoop/io/FixedLengthWithOffsetInputFormat.java
+++ b/src/main/java/org/ode/hadoop/io/FixedLengthWithOffsetInputFormat.java
@@ -49,8 +49,8 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
  *        (fail by default, can be skip of fill. If fill is chosen, then next property needs to be defined)</li>
  *     <li>FixedLengthWithOffsetInputFormat.setPartialLastRecordFillValue(conf, partialLastRecordFillValue);<br>
  *         (The byte value that should be used to fill partial last record if fill as chosen above)</li>
- *     <li>FixedLengthWithOffsetInputFormat.setRecordKeyStartAtOffset(conf, recordKeyStartAtOffset);<br>
- *         (true if record keys are to be offset-padded, false for the to start with beginning of file)</li>
+ *     <li>FixedLengthWithOffsetInputFormat.setShiftRecordKeyByOffset(conf, shiftRecordKeyByOffset);<br>
+ *         (true if record keys are to be shifted by offset, false for them to start with beginning of file)</li>
  * </ul>
  *
  * @see FixedLengthWithOffsetRecordReader
@@ -77,8 +77,8 @@ public class FixedLengthWithOffsetInputFormat
     public static final String PARTIAL_LAST_RECORD_FILL_VALUE =
             "fixedlengthwithoffsetinputformat.partiallastrecord.fillvalue";
 
-    public static final String RECORD_KEY_START_AT_OFFSET =
-            "fixedlengthwithoffsetinputformat.recordkey.offsetstart";
+    public static final String SHIFT_RECORD_KEY_BY_OFFSET =
+            "fixedlengthwithoffsetinputformat.recordkey.shiftbyoffset";
 
     /**
      * Set the size of the file header to skip
@@ -159,26 +159,25 @@ public class FixedLengthWithOffsetInputFormat
     }
 
     /**
-     * Set the value to make record-key start at offset or at beginning of file
+     * Set the value to have record-key shifted by offset or start at beginning of file
      * @param conf configuration
-     * @param recordKeyStartAtOffset The value to fill the partial last record.
+     * @param shiftRecordKeyByOffset Whether to shift or not
      */
-    public static void setRecordKeyStartAtOffset(
-            Configuration conf, boolean recordKeyStartAtOffset) {
-        conf.setBoolean(RECORD_KEY_START_AT_OFFSET, recordKeyStartAtOffset);
+    public static void setShiftRecordKeyByOffset(
+            Configuration conf, boolean shiftRecordKeyByOffset) {
+        conf.setBoolean(SHIFT_RECORD_KEY_BY_OFFSET, shiftRecordKeyByOffset);
     }
 
     /**
-     * Get the value to make record-key start at offset or at beginning of file
+     * Get the value to shift record-key by offset or not
      * @param conf configuration
-     * @return true if record-key starts with 0 at offset, false if it starts at the beginning
-     *         of file and has offset + 1 as first value.
+     * @return true if record-key is shifted by offset (meaning it starts at 0)
+     *         false if it starts at the beginning of file (meaning it starts at offset + 1)
      *         Default to true if unset.
      */
-    public static boolean getRecordKeyStartAtOffset(Configuration conf) {
-        return conf.getBoolean(RECORD_KEY_START_AT_OFFSET, true);
+    public static boolean getShiftRecordKeyByOffset(Configuration conf) {
+        return conf.getBoolean(SHIFT_RECORD_KEY_BY_OFFSET, true);
     }
-
 
 
     @Override
@@ -191,7 +190,7 @@ public class FixedLengthWithOffsetInputFormat
         long offsetSize = getOffsetSize(conf);
         String partialLastRecordAction = getPartialLastRecordAction(conf);
         byte partialLastRecordFillValue = getPartialLastRecordFillValue(conf);
-        boolean keyStartAtOffset = getRecordKeyStartAtOffset(conf);
+        boolean shiftRecordKeyByOffset = getShiftRecordKeyByOffset(conf);
 
         List<String> errors = new ArrayList<>();
 
@@ -227,7 +226,7 @@ public class FixedLengthWithOffsetInputFormat
                 recordLength,
                 partialLastRecordActionEnum,
                 partialLastRecordFillValue,
-                keyStartAtOffset
+                shiftRecordKeyByOffset
         );
     }
 

--- a/src/main/java/org/ode/hadoop/io/WavPcmRecordReader.java
+++ b/src/main/java/org/ode/hadoop/io/WavPcmRecordReader.java
@@ -129,7 +129,7 @@ public class WavPcmRecordReader extends RecordReader<LongWritable, TwoDDoubleArr
                 FixedLengthWithOffsetRecordReader.PartialLastRecordAction.valueOf(
                         this.partialLastRecordAction.toString()),
                 this.partialLastRecordZeroFill,
-                true // When reading WAVs, we want the record-key to start at offset
+                true // When reading WAVs, we want the record-key to be shifted by offset
                 );
 
     }

--- a/src/main/java/org/ode/hadoop/io/WavPcmRecordReader.java
+++ b/src/main/java/org/ode/hadoop/io/WavPcmRecordReader.java
@@ -128,7 +128,8 @@ public class WavPcmRecordReader extends RecordReader<LongWritable, TwoDDoubleArr
                 this.recordSizeInFrames * this.channels * this.sampleSizeInBytes,
                 FixedLengthWithOffsetRecordReader.PartialLastRecordAction.valueOf(
                         this.partialLastRecordAction.toString()),
-                this.partialLastRecordZeroFill
+                this.partialLastRecordZeroFill,
+                true // When reading WAVs, we want the record-key to start at offset
                 );
 
     }

--- a/src/test/java/org/ode/hadoop/io/TestFixedLengthWithOffsetInputFormat.java
+++ b/src/test/java/org/ode/hadoop/io/TestFixedLengthWithOffsetInputFormat.java
@@ -448,6 +448,10 @@ public class TestFixedLengthWithOffsetInputFormat {
                 totalRecords = 100;
                 recordLength = 1;
             }
+            boolean recordKeyStartAtOffset = true;
+            if (i == 12) {
+                recordKeyStartAtOffset = false;
+            }
             // The total bytes in the test file
             int fileSize = (offsetSize + totalRecords * recordLength);
             LOG.info("offsetSize=" + offsetSize + " totalRecords=" + totalRecords + " recordLength="
@@ -465,6 +469,8 @@ public class TestFixedLengthWithOffsetInputFormat {
             //set the fixed length record length and offset size config properties for the job
             FixedLengthWithOffsetInputFormat.setRecordLength(job.getConfiguration(), recordLength);
             FixedLengthWithOffsetInputFormat.setOffsetSize(job.getConfiguration(), offsetSize);
+            FixedLengthWithOffsetInputFormat.setRecordKeyStartAtOffset(job.getConfiguration(), recordKeyStartAtOffset);
+
 
             int numSplits = 1;
             // Arbitrarily set number of splits.
@@ -516,9 +522,11 @@ public class TestFixedLengthWithOffsetInputFormat {
                 while (reader.nextKeyValue()) {
                     key = reader.getCurrentKey();
                     value = reader.getCurrentValue();
-
-                    assertEquals("Checking key", (long)(offsetSize + recordNumber*recordLength),
-                            key.get());
+                    if (recordKeyStartAtOffset) {
+                        assertEquals("Checking key", (long) (recordNumber * recordLength), key.get());
+                    } else {
+                        assertEquals("Checking key", (long) (offsetSize + recordNumber * recordLength), key.get());
+                    }
                     String valueString = new String(value.getBytes(), 0,
                             value.getLength());
                     assertEquals("Checking record length:", recordLength,

--- a/src/test/java/org/ode/hadoop/io/TestFixedLengthWithOffsetInputFormat.java
+++ b/src/test/java/org/ode/hadoop/io/TestFixedLengthWithOffsetInputFormat.java
@@ -448,9 +448,9 @@ public class TestFixedLengthWithOffsetInputFormat {
                 totalRecords = 100;
                 recordLength = 1;
             }
-            boolean recordKeyStartAtOffset = true;
+            boolean shiftRecordKeyByOffset = true;
             if (i == 12) {
-                recordKeyStartAtOffset = false;
+                shiftRecordKeyByOffset = false;
             }
             // The total bytes in the test file
             int fileSize = (offsetSize + totalRecords * recordLength);
@@ -469,7 +469,7 @@ public class TestFixedLengthWithOffsetInputFormat {
             //set the fixed length record length and offset size config properties for the job
             FixedLengthWithOffsetInputFormat.setRecordLength(job.getConfiguration(), recordLength);
             FixedLengthWithOffsetInputFormat.setOffsetSize(job.getConfiguration(), offsetSize);
-            FixedLengthWithOffsetInputFormat.setRecordKeyStartAtOffset(job.getConfiguration(), recordKeyStartAtOffset);
+            FixedLengthWithOffsetInputFormat.setShiftRecordKeyByOffset(job.getConfiguration(), shiftRecordKeyByOffset);
 
 
             int numSplits = 1;
@@ -522,7 +522,7 @@ public class TestFixedLengthWithOffsetInputFormat {
                 while (reader.nextKeyValue()) {
                     key = reader.getCurrentKey();
                     value = reader.getCurrentValue();
-                    if (recordKeyStartAtOffset) {
+                    if (shiftRecordKeyByOffset) {
                         assertEquals("Checking key", (long) (recordNumber * recordLength), key.get());
                     } else {
                         assertEquals("Checking key", (long) (offsetSize + recordNumber * recordLength), key.get());

--- a/src/test/java/org/ode/hadoop/io/TestWavPcmInputFormat.java
+++ b/src/test/java/org/ode/hadoop/io/TestWavPcmInputFormat.java
@@ -213,7 +213,7 @@ public class TestWavPcmInputFormat {
                 key = reader.getCurrentKey();
                 value = reader.getCurrentValue();
 
-                assertEquals("Checking key", (long)(44 + recordNumber * recordSizeInFrame * 2),
+                assertEquals("Checking key", (long)(recordNumber * recordSizeInFrame * 2),
                         key.get());
                 DoubleWritable[][] valueArray = (DoubleWritable[][])value.get();
                 records.add(valueArray);
@@ -322,7 +322,7 @@ public class TestWavPcmInputFormat {
                     key = reader.getCurrentKey();
                     value = reader.getCurrentValue();
 
-                    assertEquals("Checking key", (long) (44 + recordNumber * 1000 * 2),
+                    assertEquals("Checking key", (long) (recordNumber * 1000 * 2),
                             key.get());
                     DoubleWritable[][] valueArray = (DoubleWritable[][]) value.get();
                     assertEquals("Checking record channels dim:", 1, valueArray.length);


### PR DESCRIPTION
This patch adds the possibility to choose whether the record-key
provided by the FixedLengthWithOffsetRecordReader starts at offset
(case by default, meaning that first record of a file has key = 0, even if it is read
at offset position in file), or if it start at beginning of file
(meaning first record of a file has key = offset).