### PR TITLE
Correct WavPcmRecordReader key to be in frames

### DIFF
--- a/src/main/java/org/ode/hadoop/io/WavPcmInputFormat.java
+++ b/src/main/java/org/ode/hadoop/io/WavPcmInputFormat.java
@@ -40,9 +40,10 @@ import java.util.List;
  * The format expects settings to be provided through configuration properties,
  * and validate them against the file header at RecordReader initialization.
  * The data is then read by chunks of size defined by property, and converted
- * on the fly as doubles.
+ * on the fly as doubles.<br>
  * Multiple strategies are available in case the file size is not divisible by
- * the chosen record size (fail, skip or fill, with a specified fill value).
+ * the chosen record size (fail, skip or fill, with a specified fill value).<br>
+ * The record key is the offset from the beginning of data in number of frames.
  * <br><br>
  * Properties to be set:
  * <li>

--- a/src/main/java/org/ode/hadoop/io/WavPcmRecordReader.java
+++ b/src/main/java/org/ode/hadoop/io/WavPcmRecordReader.java
@@ -73,6 +73,7 @@ public class WavPcmRecordReader extends RecordReader<LongWritable, TwoDDoubleArr
 
     // Computed parameters
     private int sampleSizeInBytes;
+    private int frameSizeInBytes;
     private double doubleOffset;
     private double doubleScale;
     private byte partialLastRecordZeroFill;
@@ -107,6 +108,7 @@ public class WavPcmRecordReader extends RecordReader<LongWritable, TwoDDoubleArr
 
         // Computed parameters
         this.sampleSizeInBytes = this.sampleSizeInBits / 8;
+        this.frameSizeInBytes = this.channels * this.sampleSizeInBytes;
 
         // Prepare double-conversion values for signal
         if (this.sampleSizeInBits > 8) {
@@ -252,7 +254,7 @@ public class WavPcmRecordReader extends RecordReader<LongWritable, TwoDDoubleArr
         // Check innerReader nextValue, and load locally after transformation
         if (this.innerReader.nextKeyValue()) {
             this.recordRead += 1;
-            this.key = this.innerReader.getCurrentKey();
+            this.key.set(this.innerReader.getCurrentKey().get() / this.frameSizeInBytes);
             byte[] recordBytes = this.innerReader.getCurrentValue().getBytes();
             if (recordBytes.length % this.channels != 0) {
                 throw new IOException("Record length in bytes " + recordBytes.length

--- a/src/test/java/org/ode/hadoop/io/TestWavPcmInputFormat.java
+++ b/src/test/java/org/ode/hadoop/io/TestWavPcmInputFormat.java
@@ -213,7 +213,7 @@ public class TestWavPcmInputFormat {
                 key = reader.getCurrentKey();
                 value = reader.getCurrentValue();
 
-                assertEquals("Checking key", (long)(recordNumber * recordSizeInFrame * 2),
+                assertEquals("Checking key", (long)(recordNumber * recordSizeInFrame),
                         key.get());
                 DoubleWritable[][] valueArray = (DoubleWritable[][])value.get();
                 records.add(valueArray);
@@ -322,7 +322,7 @@ public class TestWavPcmInputFormat {
                     key = reader.getCurrentKey();
                     value = reader.getCurrentValue();
 
-                    assertEquals("Checking key", (long) (recordNumber * 1000 * 2),
+                    assertEquals("Checking key", (long) (recordNumber * 1000),
                             key.get());
                     DoubleWritable[][] valueArray = (DoubleWritable[][]) value.get();
                     assertEquals("Checking record channels dim:", 1, valueArray.length);


### PR DESCRIPTION
The previous versions was providing key in bytes, while it makes more sense here to provide frame numbers.